### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ An MCP server for interacting with MySQL databases.
 
 This server supports executing read-only queries (query) and write queries that are ultimately rolled back (test_execute).
 
+<a href="https://glama.ai/mcp/servers/kucglstegf">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/kucglstegf/badge" alt="MySQL Server MCP server" />
+</a>
+
 ## Setup
 
 ### Environment Variables


### PR DESCRIPTION
This PR adds a badge for the [MySQL MCP Server](https://glama.ai/mcp/servers/kucglstegf) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/kucglstegf">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/kucglstegf/badge" alt="MySQL Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.